### PR TITLE
feat(TFD-10165): bump aws-java-sdk dependency

### DIFF
--- a/hadoop-tools/hadoop-aws/pom.xml
+++ b/hadoop-tools/hadoop-aws/pom.xml
@@ -23,7 +23,7 @@
     <relativePath>../../hadoop-project</relativePath>
   </parent>
   <artifactId>hadoop-aws-tlnd</artifactId>
-  <version>2.7.3.3</version>
+  <version>2.7.3.4-SNAPSHOT</version>
   <name>Apache Hadoop Amazon Web Services support</name>
   <description>
     This module contains code to support integration with Amazon Web Services.
@@ -241,9 +241,25 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.10.6</version>
+      <version>1.11.199</version>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
+      <scope>compile</scope>
+  </dependency>
+
+  <dependency>
+    <groupId>org.apache.httpcomponents</groupId>
+    <artifactId>httpcore</artifactId>
+    <version>4.4.4</version>
+    <scope>compile</scope>
+</dependency>
+
+  
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
hadoop-aws `tlnd-2.7.3.3` uses an old aw-java-sdk version that's not compatible with the MinIO gateway, this leads to some complications with the following jira : https://jira.talendforge.org/browse/TFD-10165.

The `tlnd-2.7.3.4-SNAPSHOT` has been built and published in artifact-zl for testing.